### PR TITLE
Merge pull request #28 from reallymello/master

### DIFF
--- a/packages/gatsby-theme-chronoblog/src/components/feed-items/feed-items.js
+++ b/packages/gatsby-theme-chronoblog/src/components/feed-items/feed-items.js
@@ -158,14 +158,14 @@ const YearSeparator = ({
 const Item = ({ itemsFormat, item, linksBeforeTitle = '' }) => {
   if (itemsFormat === 'compact')
     return (
-      <li key={item.id}>
+      <div key={item.id}>
         <Compact item={item} linksBeforeTitle={linksBeforeTitle} />
-      </li>
+      </div>
     );
   return (
-    <li key={item.id}>
+    <div key={item.id}>
       <Card item={item} linksBeforeTitle={linksBeforeTitle} />
-    </li>
+    </div>
   );
 };
 
@@ -282,7 +282,7 @@ export default ({
           const firstYear = yearsArray[0];
           //
           return (
-            <ul sx={listStyleObject}>
+            <div sx={listStyleObject}>
               {yearsArray.map((year) => {
                 return (
                   <YearSeparator
@@ -293,7 +293,7 @@ export default ({
                     yearSeparatorSkipFirst={yearSeparatorSkipFirstUse}
                     yearSeparatorType={yearSeparatorType}
                   >
-                    <ul sx={listStyleObject}>
+                    <div sx={listStyleObject}>
                       {feedItemsToShow.map((item) => {
                         if (getItemYear(item) === year) {
                           return (
@@ -306,11 +306,11 @@ export default ({
                         }
                         return undefined;
                       })}
-                    </ul>
+                    </div>
                   </YearSeparator>
                 );
               })}
-            </ul>
+            </div>
           );
         }}
       </Location>


### PR DESCRIPTION
https://dequeuniversity.com/rules/axe/3.0/list

Changed the ul and li tags to divs. This allows the theme to get a 100 passing rate now on the lighthouse accessibility score. WCAG guidelines don't allow you to put content outside of li, script, and templates inside ordered and unordered lists.

I didn't see any issues with layout arising from the change. Unless there is backhistory on why the layout was using a list to show the posts before this seems like a safe change.