### PR TITLE
fix: specify gql schema to prevent cover inferrence error

### DIFF
--- a/packages/gatsby-theme-chronoblog/gatsby-node.js
+++ b/packages/gatsby-theme-chronoblog/gatsby-node.js
@@ -53,6 +53,42 @@ exports.onPreBootstrap = ({ store }) => {
   });
 };
 
+// These types need to match the gatsby-mdx-plugin's inferred result exactly
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions;
+  createTypes(`
+    type MdxFrontmatter {
+      cover: File
+      title: String
+      date: Date
+      link: String
+      hide: Boolean
+      draft: Boolean
+      description: String
+      tags: [String]
+    }
+
+    type Fields {
+      slug: String
+      type: String
+    }
+
+    type Headings {
+      value: String
+      depth: Int
+    }
+
+    type Mdx implements Node {
+      id: String
+      excerpt: String
+      frontmatter: MdxFrontmatter
+      fields: Fields
+      headings: Headings
+      body: String
+    }
+  `);
+};
+
 exports.onCreateNode = ({ node, actions, getNode }) => {
   //
   if (node.internal.type !== 'Mdx') return;


### PR DESCRIPTION
Relevant: https://github.com/Chronoblog/gatsby-theme-chronoblog/issues/21

I'm new to Gatsby, so am not confident this is the right way to solve
this. In particular, my reading led me to expect to only need to specify
the types down to the `cover` field, while the rest should be inferred.
However, doing this led to errors - the other types couldn't be found,
and a few other warnings showed up that might be relevant.

Doesn't feel like the ideal solution, but it solves the error I had, so
I thought I'd at least get this PR open.

Relevant links:

- https://stackoverflow.com/questions/54292012/handle-empty-strings-as-image-paths-when-using-gatsby-transformer-sharp/54346068#54346068
- https://stackoverflow.com/questions/50770217/how-to-give-gatsby-a-graphql-schema
- https://www.gatsbyjs.org/blog/2019-03-18-releasing-new-schema-customization/
- https://www.gatsbyjs.org/docs/schema-customization/

The root of the error is the `cover` field being detected as an empty
string (hence, `String` as the gql type) in some frontmatters before the
`File` type can be inferred from another post.

Gatsby opened APIs to allow for overriding types like these, but they're
supposed to merge your customized types with the inferred fields
somewhere in the pipeline - that does not appear to be happening here,
not sure why.