### PR TITLE
Update date.js

### DIFF
--- a/packages/gatsby-theme-chronoblog/src/components/date.js
+++ b/packages/gatsby-theme-chronoblog/src/components/date.js
@@ -18,7 +18,7 @@ const makeDate = (date, language, options) => {
 
 export default ({
   date,
-  options = { year: 'numeric', month: 'long', day: 'numeric' },
+  options = { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' },
   fontSize = [1],
   ...props
 }) => {


### PR DESCRIPTION
@Ganevru, I am experiencing the same described here: https://github.com/Chronoblog/gatsby-theme-chronoblog/issues/25

This tiny PR isn't the most elegant one, but it does prevent the issue from happening. (Since this is my first PR here, I decided to go as simple as possible.)

A solution to consider in the future (depending on your plans) is to add a timeZone option in `siteMetadata` (`gatsby-config.js`) and then parse it appropriately inside `date.js`.

---

The root cause of the issue is that in our frontmatters (as per the starters examples) we input dates in the following format:

```yml
date: 2020-08-13
```

When you insert that string into the `Date` constructor, `Date` objects are (implicitly) created with 00:00:00 time and UTC as their time zone:

```js
// https://github.com/Chronoblog/gatsby-theme-chronoblog/blob/master/packages/gatsby-theme-chronoblog/src/components/date.js#L14
const newDate = new Date(date);
```

Then, when you convert the `newDate` using `toLocaleString(language, options)` to our local time zones, things can get weird.

Because @reallymello (Florida) and I live in time zones that are UTC-3 (or more) we noticed the issue. All our posts/notes/links are showed in the feed with the frontmatter day minus 1.

I assume you haven't noticed anything on your side because it seems you live in Moscow (which is UTC+3, give or take). Your days are never shifted!

---

Well, that's a very long explanation for such a tiny PR. 😅 

In any case, thanks again for creating this great theme!